### PR TITLE
Tweet.In_reply_to_status_id type is string and should be int64.

### DIFF
--- a/twittertypes.go
+++ b/twittertypes.go
@@ -40,7 +40,7 @@ type Tweet struct {
 	Favorited               bool
 	Source                  string
 	Contributors            string
-	In_reply_to_status_id   string
+	In_reply_to_status_id   int64
 	In_reply_to_user_id     int64
 	Id                      int64
 	Id_str                  string


### PR DESCRIPTION
This is defined in twittertypes.go

Other 'id' types are int64, so maybe this is an oversight?

This caused the error 'json: cannot unmarshal number into Go value of type string' when unmarshalling JSON returned by the Twitter REST API. The error was fixed by changing the type.

BTW, twitter also returns a 'in_reply_to_status_id_str' value if a string is needed, although this value is not set in this file.
